### PR TITLE
add ability to listen to raw startElement, endElement events

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -170,10 +170,10 @@ XmlStream.prototype.preserve = function(selector, whitespace) {
 // Normalizes the selector and returns the new version and its parts.
 function normalizeSelector(selector) {
   var parts = selector.match(/[^\s>]+|>/ig);
-  selector = parts.join(' ');
+  selector = (parts) ? parts.join(' ') : '';
   return {
-    normalized: parts.join(' '),
-    parts: parts
+    normalized: selector,
+    parts: parts || []
   };
 }
 
@@ -188,7 +188,8 @@ function parseEvent(event) {
   return {
     selector: selector,
     type: eventType,
-    name: eventType + ': ' + selector.normalized
+    name: (eventParts[2]) ? eventType + ': ' + selector.normalized
+                          : eventType
   };
 }
 
@@ -319,6 +320,7 @@ function parse() {
   // Here we traverse the configured finite automata use the stack
   // to form the context and trace for selector event emission.
   xml.on('startElement', function(name, attr) {
+    self.emit('startElement', name, attr);
     stack.push(curr);
     trace[curr.path] = curr.element;
     var context = Object.create(curr.context);
@@ -366,6 +368,7 @@ function parse() {
   // invoked with current node, context, and trace; these arguments are
   // removed from the stack afterwards.
   xml.on('endElement', function(name) {
+    self.emit('endElement', name);
     var prev = stack.pop();
     var element = curr.element;
     var text = curr.fullText;


### PR DESCRIPTION
Hello, 

You have a great module. Thank you for writing it. The ability to listen to the raw events emitted by expat is very useful. The docs suggest that the listener selector is optional (`startElement[: selector]`), however, there were a couple of lines of code preventing me from adding a plain start/endElement listener. This pull request makes those changes. 

Thank you, 

David Greisen.
