### PR TITLE
Bump node-expat to ~1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "iconv": "~1.1.2",
-    "node-expat": "~1.3.1"
+    "node-expat": "~1.4.0"
   },
   "engines": {
     "node": ">=0.4.7"


### PR DESCRIPTION
Bump the version of node-expat to 1.4.0 to fix build problems I've been experiencing on both MacOSX and Fedora 16 using quite recent 0.6.x-versions of Node.js. Not sure why this solves it.
