### PR TITLE
Bumping node-expat version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "iconv": "~1.1.3",
-    "node-expat": "~1.4.3"
+    "node-expat": "~2.0.0"
   },
   "engines": {
     "node": ">=0.6.0"


### PR DESCRIPTION
I was having problem npm-installing xml-stream due to errors while compiling node-expat.
It works using the latest one.
