### PR TITLE
Checking for "utf-8" made case-insensitive.

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -69,7 +69,7 @@ function XmlStream(stream, encoding) {
 
 // Either make an iconv instance, or not.
 function makeEncoder(encoding) {
-  if (encoding && !/^utf-?8$/.test(encoding)) {
+  if (encoding && !/^utf-?8$/i.test(encoding)) {
     return new Iconv(encoding, 'utf8');
   }
   return null;


### PR DESCRIPTION
Recommended spelling of "UTF-8" in XML documents is in uppercase.  With case-sensitive matching for lowercase "utf-8" node-iconv was needlessly called, throwing EINVAL.
