### PR TITLE
Bump iconv dependency to ~2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/assistunion/xml-stream.git"
   },
   "dependencies": {
-    "iconv": "~1.1.3",
+    "iconv": "~2.0.0",
     "node-expat": "~2.0.0"
   },
   "engines": {


### PR DESCRIPTION
This makes it so that xml-stream will work in node v0.10.x, by using a version of iconv that uses gyp instead of node-waf.
