### PR TITLE
Remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "iconv": "~1.1.3",
     "node-expat": "~2.0.0"
   },
-  "engines": {
-    "node": ">=0.6.0"
-  },
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
A minor change: This removes the engines field from the package.json. Pedantry I know, but I was digging into this file anyway. Do with this what you will.
