### PR TITLE
make class methods chainable

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -140,6 +140,8 @@ XmlStream.prototype.on = function(eventName, listener) {
     }
     XmlStream.super_.prototype.on.call(this, eventName, listener);
   }
+
+  return this;
 };
 
 // Collects elements with identical names, specified by a selector.
@@ -151,6 +153,8 @@ XmlStream.prototype.collect = function(selector) {
   this._fa.on('flag', finalState, function() {
     self._collect = true;
   });
+
+  return this;
 };
 
 // Preserves the order of element and text nodes inside elements
@@ -171,6 +175,8 @@ XmlStream.prototype.preserve = function(selector, whitespace) {
       self._preserveWhitespace--;
     }
   });
+
+  return this;
 };
 
 // pause expat
@@ -180,6 +186,8 @@ XmlStream.prototype.pause = function() {
   if( !this._parser.pause() ) {
       throw(new Error("Cannot pause parser: "+this._parser.getError()));
   }
+
+  return this;
 }
 
 // resume expat
@@ -194,6 +202,8 @@ XmlStream.prototype.resume = function() {
   if( !this._suspended ) {
     this._stream.resume();
   }
+
+  return this;
 }
 
 // Normalizes the selector and returns the new version and its parts.


### PR DESCRIPTION
Just a bit of syntax 'sugar' so i can do this;
````javascript
xml
  .preserve('id')
  .collect('doc')
  .on('endElement: item', function(item) {
    console.log(item);
  })
  ;
````