### PR TITLE
Update node-expat to work with node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "iconv": "^2.1.4",
-    "node-expat": "^2.3.1",
+    "node-expat": "^2.3.7",
     "readable-stream": "^1.0.31"
   },
   "directories": {


### PR DESCRIPTION
Following: https://github.com/node-xmpp/node-expat/issues/112

This version of node-expat includes updates required to compile and work with iojs and node 0.12