### PR TITLE
wait a second to emit end event when xml-stream is suspended

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -548,6 +548,12 @@ function parse() {
 
   // End parsing on stream EOF and emit an *end* event ourselves.
   this._stream.on('end', function() {
+    if (self._suspended) {
+      return setTimeout(function() {
+        self._stream.emit('end');
+      }, 1000);
+    }
+
     if (!xml.parse('', true)) {
       self.emit('error', new Error(xml.getError()+" in line "+xml.getCurrentLineNumber()));
     }


### PR DESCRIPTION
https://github.com/assistunion/xml-stream/issues/66
