### PR TITLE
Allow single quotes in encoding parsing regexp

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -536,7 +536,7 @@ function parse() {
       preludeBuffers.push(data);
       prelude += data.toString();
       if (/^\s*<[^>]+>/.test(prelude)) {
-        var matches = prelude.match(/^\s*<\?xml[^>]+encoding="(.+?)"[^>]*\?>/);
+        var matches = prelude.match(/^\s*<\?xml[^>]+encoding=['"](.+?)['"][^>]*\?>/);
         self._encoding = matches ? matches[1] : 'utf8';
         self._encoder = makeEncoder(self._encoding);
         for (var i = 0, n = preludeBuffers.length; i < n; i++) {


### PR DESCRIPTION
Now `xml-stream` can only parse an encoding attribute enclosed in double quotes, while xml standard supports single quotes too. This PR is intended to allow using single quotes in the encoding attribute as well.