### PR TITLE
Added compatibility for error handling with event

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -110,6 +110,11 @@ XmlStream.prototype = Object.create(events.EventEmitter.prototype, {
 // * `ancestor descendant`
 // * `parent > child`
 XmlStream.prototype.on = function(eventName, listener) {
+  if (eventName === 'error') {
+    XmlStream.super_.prototype.on.call(this, eventName, listener);
+    return this;
+  }
+
   var event = parseEvent(eventName);
   if (event !== null) {
     // If we're dealing with a selector event,
@@ -521,7 +526,7 @@ function parse() {
       data = self._encoder.convert(data);
     }
     if (!xml.parse(data, false)) {
-      throw new Error(xml.getError()+" in line "+xml.getCurrentLineNumber());
+      self.emit('error', new Error(xml.getError()+" in line "+xml.getCurrentLineNumber()));
     }
   }
 
@@ -549,8 +554,7 @@ function parse() {
   // End parsing on stream EOF and emit an *end* event ourselves.
   this._stream.on('end', function() {
     if (!xml.parse('', true)) {
-      self.emit('end');
-      throw new Error(xml.getError()+" in line "+xml.getCurrentLineNumber());
+      self.emit('error', new Error(xml.getError()+" in line "+xml.getCurrentLineNumber()));
     }
     self.emit('end');
   });

--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -521,7 +521,7 @@ function parse() {
       data = self._encoder.convert(data);
     }
     if (!xml.parse(data, false)) {
-      self.emit('error', new Error(xml.getError()+" in line "+xml.getCurrentLineNumber()));
+      throw new Error(xml.getError()+" in line "+xml.getCurrentLineNumber());
     }
   }
 
@@ -549,7 +549,8 @@ function parse() {
   // End parsing on stream EOF and emit an *end* event ourselves.
   this._stream.on('end', function() {
     if (!xml.parse('', true)) {
-      self.emit('error', new Error(xml.getError()+" in line "+xml.getCurrentLineNumber()));
+      self.emit('end');
+      throw new Error(xml.getError()+" in line "+xml.getCurrentLineNumber());
     }
     self.emit('end');
   });


### PR DESCRIPTION
I don't know if actually this is the best way to do it, but It can be useful to handle errors thrown by XML parsing by using .on('error', function(e))